### PR TITLE
Update CSP rules for rss2json

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <title>BeCompany news</title>
   <base href="/">
 
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *; connect-src 'self' https://rss2json.com ws://localhost:4200">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *; connect-src 'self' https://rss2json.com https://api.rss2json.com ws://localhost:4200">
   <meta name="format-detection" content="telephone=no">
   <meta name="msapplication-tap-highlight" content="no">
   <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width">


### PR DESCRIPTION
Seems like the rss2json service uses now the address api.rss2json.com. We need to add this value to the CSP rules.